### PR TITLE
WIP:showing party name in edit page

### DIFF
--- a/app/view/party/manage.php
+++ b/app/view/party/manage.php
@@ -104,7 +104,7 @@
                         </div>
 
                         <div class="short-body">
-                            <span class="location"><?php echo (!empty($party->venue) ? $party->venue . ', ' . $party->location : $party->location); ?></span><br />
+                            <span class="location"><?php echo (!empty($party->venue) ? $party->venue : $party->location); ?></span><br />
                             <span class="groupname"><?php echo $party->group_name; ?></span>
                         </div>
                     </div>


### PR DESCRIPTION
Displays party name only. In the absence of party name it displays location of the party.